### PR TITLE
Add billing to list of autocomplete tokens

### DIFF
--- a/js/audits.js
+++ b/js/audits.js
@@ -12,12 +12,12 @@ let inputsSelectsTextareas;
 // From https://html.spec.whatwg.org/multipage/form-control-infrastructure.html
 const AUTOCOMPLETE_TOKENS = ['additional-name', 'address-level1', 'address-level2',
   'address-level3', 'address-level4', 'address-line1', 'address-line2', 'address-line3', 'bday',
-  'bday-day', 'bday-month', 'bday-year', 'cc-additional-name', 'cc-csc', 'cc-exp', 'cc-exp-month',
+  'bday-day', 'bday-month', 'bday-year', 'billing', 'cc-additional-name', 'cc-csc', 'cc-exp', 'cc-exp-month',
   'cc-exp-year', 'cc-family-name', 'cc-given-name', 'cc-name', 'cc-number', 'cc-type', 'country',
   'country-name', 'current-password', 'email', 'family-name', 'fax', 'given-name', 'home', 'honorific-prefix',
   // Allow 'on'.
   'honorific-suffix', 'impp', 'language', 'mobile', 'name', 'new-password', 'nickname', 'on', 'one-time-code',
-  'organization', 'organization-title', 'pager', 'photo', 'postal-code', 'sex', 'shipping', 'billing', 'street-address',
+  'organization', 'organization-title', 'pager', 'photo', 'postal-code', 'sex', 'shipping', 'street-address',
   'tel', 'tel-area-code', 'tel-country-code', 'tel-extension', 'tel-local', 'tel-national',
   'transaction-amount', 'transaction-currency', 'url', 'username', 'work'];
 

--- a/js/audits.js
+++ b/js/audits.js
@@ -17,7 +17,7 @@ const AUTOCOMPLETE_TOKENS = ['additional-name', 'address-level1', 'address-level
   'country-name', 'current-password', 'email', 'family-name', 'fax', 'given-name', 'home', 'honorific-prefix',
   // Allow 'on'.
   'honorific-suffix', 'impp', 'language', 'mobile', 'name', 'new-password', 'nickname', 'on', 'one-time-code',
-  'organization', 'organization-title', 'pager', 'photo', 'postal-code', 'sex', 'shipping', 'street-address',
+  'organization', 'organization-title', 'pager', 'photo', 'postal-code', 'sex', 'shipping', 'billing', 'street-address',
   'tel', 'tel-area-code', 'tel-country-code', 'tel-extension', 'tel-local', 'tel-national',
   'transaction-amount', 'transaction-currency', 'url', 'username', 'work'];
 


### PR DESCRIPTION
Audit does not correctly recognize billing autocomplete fields according to [html.spec.whatwg.org](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#:~:text=%22billing%22%2C%20meaning%20the%20field%20is%20part%20of%20the%20billing%20address%20or%20contact%20information).

Fixes #8