### PR TITLE
build: add manually triggered workflow to bump version number

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -1,0 +1,23 @@
+name: bump version
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version number
+        required: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: bump version
+        run: |
+          git config --global user.name '${{ github.actor }}'
+          git config --global user.email '${{ github.actor }}@users.noreply.github.com'
+          git commit -m "chore: bump version to ${{ github.event.inputs.version }}
+
+          release-as: ${{ github.event.inputs.version }}" --allow-empty
+          git push


### PR DESCRIPTION
This change will make it possible to bump the version of the next release without having to commit any code.

![image](https://user-images.githubusercontent.com/2647062/128582455-2f376496-fa9a-4d8a-be8f-25f849f6b610.png)

Anyone with write access to the repository will be able to trigger a version bump.