### PR TITLE
fix: revert back to not mutating tree nodes

### DIFF
--- a/src/lib/audits/inputs.ts
+++ b/src/lib/audits/inputs.ts
@@ -48,12 +48,14 @@ export function inputHasLabel(tree: TreeNodeWithParent): AuditResult | undefined
   );
   const invalidFields = eligibleFields
     .filter(node => !closestParent(node, 'label'))
-    .map(node => {
-      const contextNode: TreeNodeWithContext<ContextReasons> = node;
-      // mutating node instead of returning a new one to keep object identity the same
-      contextNode.context = { reasons: [] };
-      return contextNode;
-    })
+    .map(
+      node =>
+        ({
+          ...node,
+          original: node,
+          context: { reasons: [] },
+        } as TreeNodeWithContext<ContextReasons>),
+    )
     .filter(node => {
       if (node.attributes.id) {
         node.context?.reasons.push({ type: 'id', reference: node.attributes.id });

--- a/src/lib/audits/labels.ts
+++ b/src/lib/audits/labels.ts
@@ -29,12 +29,14 @@ export function hasUniqueLabels(tree: TreeNodeWithParent): AuditResult | undefin
   const eligibleFields = findDescendants(tree, ['label']);
   const labelsByForm = groupBy(
     eligibleFields
-      .map(node => {
-        const contextNode: TreeNodeWithContext<ContextText> = node;
-        // mutating node instead of returning a new one to keep object identity the same
-        contextNode.context = { text: getTextContent(node) };
-        return contextNode;
-      })
+      .map(
+        node =>
+          ({
+            ...node,
+            original: node,
+            context: { text: getTextContent(node) },
+          } as TreeNodeWithContext<ContextText>),
+      )
       .filter(field => field.context?.text),
     node => closestParent(node, 'form'),
   );
@@ -48,11 +50,14 @@ export function hasUniqueLabels(tree: TreeNodeWithParent): AuditResult | undefin
       auditType: 'label-unique',
       items: duplicates.map(fields => {
         const [first, ...others] = fields as TreeNodeWithContext<ContextDuplicates>[];
-        // mutating node instead of returning a new one to keep object identity the same
-        first.context = {
-          duplicates: others,
+
+        return {
+          ...first,
+          original: first.original,
+          context: {
+            duplicates: others,
+          },
         };
-        return first;
       }),
       score: 1 - duplicates.reduce((total, fields) => total + fields.length, 0) / eligibleFields.length,
     };
@@ -66,12 +71,14 @@ export function hasUniqueLabels(tree: TreeNodeWithParent): AuditResult | undefin
 export function hasLabelWithValidElements(tree: TreeNodeWithParent): AuditResult | undefined {
   const eligibleFields = findDescendants(tree, ['label']);
   const invalidFields = eligibleFields
-    .map(node => {
-      const contextNode: TreeNodeWithContext<ContextFields> = node;
-      // mutating node instead of returning a new one to keep object identity the same
-      contextNode.context = { fields: findDescendants(node, ['a', 'button', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6']) };
-      return contextNode;
-    })
+    .map(
+      node =>
+        ({
+          ...node,
+          original: node,
+          context: { fields: findDescendants(node, ['a', 'button', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6']) },
+        } as TreeNodeWithContext<ContextFields>),
+    )
     .filter(field => field.context?.fields.length);
 
   if (invalidFields.length) {
@@ -96,11 +103,14 @@ export function hasLabelWithUniqueForAttribute(tree: TreeNodeWithParent): AuditR
       auditType: 'label-unique',
       items: duplicates.map(fields => {
         const [first, ...others] = fields as TreeNodeWithContext<ContextDuplicates>[];
-        // mutating node instead of returning a new one to keep object identity the same
-        first.context = {
-          duplicates: others,
+
+        return {
+          ...first,
+          original: first,
+          context: {
+            duplicates: others,
+          },
         };
-        return first;
       }),
       score: 1 - duplicates.reduce((total, fields) => total + fields.length, 0) / eligibleFields.length,
     };
@@ -133,12 +143,14 @@ export function hasInput(tree: TreeNodeWithParent): AuditResult | undefined {
   const labels = findDescendants(tree, ['label']);
 
   const invalidFields = labels
-    .map(node => {
-      const contextNode: TreeNodeWithContext<ContextReasons> = node;
-      // mutating node instead of returning a new one to keep object identity the same
-      contextNode.context = { reasons: [] };
-      return contextNode;
-    })
+    .map(
+      node =>
+        ({
+          ...node,
+          original: node,
+          context: { reasons: [] },
+        } as TreeNodeWithContext<ContextReasons>),
+    )
     .filter(node => {
       const emptyFor = node.attributes.for != null && node.attributes.for.trim() === '';
       const invalidFor = node.attributes.for && !inputsById.has(node.attributes.for);

--- a/src/lib/tree-util.ts
+++ b/src/lib/tree-util.ts
@@ -99,7 +99,7 @@ export function getPath(node: TreeNodeWithParent): string {
 /**
  * Gets a parent unique path segment for the node
  */
-function getPathSegment(node: TreeNodeWithParent): string {
+function getPathSegment(node: TreeNodeWithParent | TreeNodeWithContext<unknown>): string {
   if (node.type) {
     return node.type;
   }
@@ -124,10 +124,11 @@ function getPathSegment(node: TreeNodeWithParent): string {
   if (siblingsOfType?.length === 1) {
     return node.name;
   } else {
-    const index = siblingsOfType!.indexOf(node);
+    const lookupNode = (node as TreeNodeWithContext<unknown>).original ?? node;
+    const index = siblingsOfType!.indexOf(lookupNode);
     if (index === -1) {
-      console.log('node', node);
-      throw new Error('Node not found among siblings, node identity may have changed in one of the audits');
+      console.log('node', lookupNode);
+      throw new Error('Node not found among siblings');
     }
     return `${node.name}[${index}]`;
   }

--- a/src/lib/types.d.ts
+++ b/src/lib/types.d.ts
@@ -28,6 +28,7 @@ interface TreeNodeWithParent extends TreeNode {
 }
 
 interface TreeNodeWithContext<T> extends TreeNodeWithParent {
+  original?: TreeNodeWithParent;
   context?: T;
 }
 

--- a/src/routes/results/result-item.tsx
+++ b/src/routes/results/result-item.tsx
@@ -324,8 +324,7 @@ const auditPresenters: { [auditType: string]: AuditTypePresenter } = {
     ],
   },
   'label-no-field': {
-    title:
-      'Make forms easier to use and more accessible by associating every label with a form field',
+    title: 'Make forms easier to use and more accessible by associating every label with a form field',
     render: result => (
       <Fragment>
         <p>


### PR DESCRIPTION
Mutating tree nodes was causing audit context to be overwritted by multiple audits. This change avoids such conflict. Instead a reference to the original item will be maintained.

Fixes #50