### PR TITLE
fix: store tree as string instead of JSON

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -75,7 +75,7 @@ const App: FunctionalComponent = () => {
       chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
         if (request.message === 'stored element data') {
           chrome.storage.local.get(['tree'], result => {
-            setTree(result.tree);
+            setTree(JSON.parse(result.tree));
           });
         }
       });

--- a/src/lib/content-script.ts
+++ b/src/lib/content-script.ts
@@ -19,7 +19,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
           console.error('chrome.storage.local.clear() error in content-script.js:', error);
         } else {
           getDocumentTree(document).then(tree => {
-            chrome.storage.local.set({ tree }, () => {
+            chrome.storage.local.set({ tree: JSON.stringify(tree) }, () => {
               chrome.runtime.sendMessage({ message: 'stored element data' });
             });
           });


### PR DESCRIPTION
`chrome.storage.local.set` appears to have an issue with storing some JSON payloads. This fix manually `stringify`s and `parse`s the message the tree during the `set` and `get` operations.

Fixes #53