### PR TITLE
fix: update dom traversal logic to also take the current element's visibility

### DIFF
--- a/src/lib/dom-iterator.ts
+++ b/src/lib/dom-iterator.ts
@@ -80,7 +80,7 @@ export function getNodesByParent(node: Node): Map<Node | null, Node[]> {
   while ((currentNode = walker.nextNode())) {
     const parent = currentNode.parentNode;
 
-    if (isElementVisible(parent)) {
+    if (isElementVisible(parent) || isElementVisible(currentNode)) {
       if (nodesByParent.has(parent)) {
         nodesByParent.get(parent)?.push(currentNode);
       } else {


### PR DESCRIPTION
In one scenario, the parent's `display` was set to `contents` which was causing the `offsetParent` and other related display fields to evaluate to not being visible.

This change checks for both the parent and current element visbility.

Fixes #78