### PR TITLE
chore: zero out manifest version number to avoid confusion

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Form Troubleshooter",
   "description": "Find and fix common form problems.",
-  "version": "1.2.0",
+  "version": "0.0.0",
   "manifest_version": 3,
   "background": {
     "service_worker": "background.js"


### PR DESCRIPTION
The manifest version number is automaticually updated when the package is published (`scripts/publish.sh`)